### PR TITLE
Remove an unnecessary call to `.into()`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -838,7 +838,7 @@ impl Document {
             let text = text.replace("'", "");
             let text = text.trim().to_lowercase();
 
-            if potential_titles.contains_key(text.as_str().into()) {
+            if potential_titles.contains_key(text.as_str()) {
                 tb.add_labels(&[Label::Title]);
                 has_changed = true;
                 break;


### PR DESCRIPTION
This call is converting a type to itself, and the code compiles fine
without it. Having it makes the code more fragile, breaking if another
impl becomes available.
